### PR TITLE
Fix Bug in RandomForestClassifier When Scores are Less than One

### DIFF
--- a/everywhereml/templates/sklearn/ensemble/cpp/RandomForestClassifier.cpp.jinja
+++ b/everywhereml/templates/sklearn/ensemble/cpp/RandomForestClassifier.cpp.jinja
@@ -1,7 +1,7 @@
 {% extends 'BaseClassifier' %}
 
 {% block predict %}
-    uint16_t votes[{{ this.num_outputs }}] = { 0 };
+    float votes[{{ this.num_outputs }}] = { 0 };
     uint8_t classIdx = 0;
     float classScore = 0;
 


### PR DESCRIPTION
There's a bug in the RandomForestClassifier where scores are not accumulated when they are less than one. There are also other related failure cases. The cause is that that the type for the `votes` variable is an `int` type instead of `float`. This one line change fixes the bug. 
The `classScore` variable used to retrieve scores from each tree is already correctly typed as `float`, making it easy to see that this is indeed a bug.